### PR TITLE
fix: rename 10-writecache.conf to 99-writecache.conf

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -9,7 +9,7 @@ remove_action() {
   dpkg-trigger update-workbench
   rm -rf /etc/omv-writecache
 
-  conf="/etc/systemd/journald.conf.d/10-writecache.conf"
+  conf="/etc/systemd/journald.conf.d/99-writecache.conf"
   if [ -e "${conf}" ]; then
     rm -f "${conf}" || true
     systemctl reload systemd-journald 2>/dev/null || systemctl try-restart systemd-journald || true

--- a/srv/salt/omv/deploy/writecache/default.sls
+++ b/srv/salt/omv/deploy/writecache/default.sls
@@ -97,7 +97,7 @@ configure_writecache_journald_dir:
 
 configure_writecache_journald:
   file.managed:
-    - name: /etc/systemd/journald.conf.d/10-writecache.conf
+    - name: /etc/systemd/journald.conf.d/99-writecache.conf
     - contents: |
         {{ pillar['headers']['auto_generated'] }}
         {{ pillar['headers']['warning'] }}

--- a/usr/sbin/omv-writecache
+++ b/usr/sbin/omv-writecache
@@ -470,7 +470,7 @@ def run(cmd, check=True, quiet=False):
     return res
 
 def ensure_persistent_journal():
-    conf_path = "/etc/systemd/journald.conf.d/10-writecache.conf"
+    conf_path = "/etc/systemd/journald.conf.d/99-writecache.conf"
     journal_dir = "/var/log/journal"
 
     # Check if Storage=persistent is set


### PR DESCRIPTION
This ensures it is not overridden (e.g. by raspberrypi-sys-mods)
(Fixes [this issue reported in forum](https://forum.openmediavault.org/index.php?thread/58672-is-it-normal-omv-8-install-script-change-var-partitions-or-mounts-point/&postID=435890#post435890))